### PR TITLE
Always allow access to login and authentication routes

### DIFF
--- a/google_oauth.routing.yml
+++ b/google_oauth.routing.yml
@@ -3,11 +3,11 @@ google_oauth.authenticate:
   defaults:
     _controller: '\Drupal\google_oauth\Controller\GoogleOAuthController::authenticate'
   requirements:
-    _permission: 'access content'
+    _access: 'TRUE'
 google_oauth.login:
   path: '/google-login'
   defaults:
     _controller: '\Drupal\google_oauth\Controller\GoogleOAuthController::login'
   requirements:
-    _permission: 'access content'
+    _access: 'TRUE'
 


### PR DESCRIPTION
If the anonymous user doesn't have `access content` permission, they can't access the login page.

This modification enables access to the routes no matter what.

https://www.drupal.org/node/2092643#section-requirements