### PR TITLE
Don't create a new Drupal account when site settings don't allow it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Drupal 8 Google Login
 
-Allows users to log in to your site using their google account. Creates a new account for a google user. This module requires the `google/apiclient` composer module, specified in this plugin's `composer.json` file.
+Allows users to log in to your site using their Google account.
+Creates a new Drupal account when the Google account is not yet known, unless
+site settings disallow user self-registration.
+This module requires the `google/apiclient` composer module, specified in this plugin's `composer.json` file.
 
 # Installation
 

--- a/src/Controller/GoogleOAuthController.php
+++ b/src/Controller/GoogleOAuthController.php
@@ -72,7 +72,7 @@ class GoogleOAuthController extends ControllerBase {
       $user_config = \Drupal::config('user.settings');
       $registration_allowed = $user_config->get('register');
       if ('visitors' != $registration_allowed) {
-          // don't create a new account if site settings don't allow to do so
+          // If settings don't allow to create a new account, then don't.
           drupal_set_message(
             t('You can\'t login using this account. Please use another e-mail address or ask an administrator to setup an account.'),
             'error'

--- a/src/Controller/GoogleOAuthController.php
+++ b/src/Controller/GoogleOAuthController.php
@@ -17,12 +17,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class GoogleOAuthController extends ControllerBase {
     
   private $client;
-  protected $configFactory;
+  protected $config_factory;
 
   public function __construct(ConfigFactoryInterface $config_factory) {
     $private_path = PrivateStream::basePath();
     $config_file = $private_path . '/google-oauth-secret.json';
-    $this->configFactory = $config_factory;
+    $this->config_factory = $config_factory;
 
     if (!is_readable($config_file)) {
       // Nag ?
@@ -83,7 +83,7 @@ class GoogleOAuthController extends ControllerBase {
     $user = user_load_by_mail($user_email);
 
     if (!$user) {
-      $user_settings = $this->configFactory->get('user.settings');
+      $user_settings = $this->config_factory->get('user.settings');
       if ($user_settings->get('register') !== 'visitors') {
           // If settings don't allow to create a new account, then don't.
           drupal_set_message(

--- a/src/Controller/GoogleOAuthController.php
+++ b/src/Controller/GoogleOAuthController.php
@@ -69,6 +69,17 @@ class GoogleOAuthController extends ControllerBase {
     $user = user_load_by_mail($user_email);
 
     if (!$user) {
+      $user_config = \Drupal::config('user.settings');
+      $registration_allowed = $user_config->get('register');
+      if ('visitors' != $registration_allowed) {
+          // don't create a new account if site settings don't allow to do so
+          drupal_set_message(
+            t('You can\'t login using this account. Please use another e-mail address or ask an administrator to setup an account.'),
+            'error'
+          );
+          return new RedirectResponse('/');
+      }
+      
       $user_name = $userinfo['name'];
       $user_picture = $userinfo['picture'];
 

--- a/src/Controller/GoogleOAuthController.php
+++ b/src/Controller/GoogleOAuthController.php
@@ -71,7 +71,7 @@ class GoogleOAuthController extends ControllerBase {
     if (!$user) {
       $user_config = \Drupal::config('user.settings');
       $registration_allowed = $user_config->get('register');
-      if ('visitors' != $registration_allowed) {
+      if ($registration_allowed !== 'visitors') {
           // If settings don't allow to create a new account, then don't.
           drupal_set_message(
             t('You can\'t login using this account. Please use another e-mail address or ask an administrator to setup an account.'),

--- a/src/Controller/GoogleOAuthController.php
+++ b/src/Controller/GoogleOAuthController.php
@@ -4,6 +4,7 @@
  */
 namespace Drupal\google_oauth\Controller;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\StreamWrapper\PrivateStream;
@@ -11,13 +12,17 @@ use Drupal\user\Entity\User;
 use Google_Client;
 use Google_Service_Oauth2;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class GoogleOAuthController extends ControllerBase {
+    
   private $client;
+  protected $configFactory;
 
-  public function __construct() {
+  public function __construct(ConfigFactoryInterface $config_factory) {
     $private_path = PrivateStream::basePath();
     $config_file = $private_path . '/google-oauth-secret.json';
+    $this->configFactory = $config_factory;
 
     if (!is_readable($config_file)) {
       // Nag ?
@@ -34,6 +39,15 @@ class GoogleOAuthController extends ControllerBase {
     $uri = \Drupal::url('google_oauth.authenticate', array(), array('absolute' => TRUE));
 
     $this->client->setRedirectUri($uri);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
   }
 
   public function login() {
@@ -69,9 +83,8 @@ class GoogleOAuthController extends ControllerBase {
     $user = user_load_by_mail($user_email);
 
     if (!$user) {
-      $user_config = \Drupal::config('user.settings');
-      $registration_allowed = $user_config->get('register');
-      if ($registration_allowed !== 'visitors') {
+      $user_settings = $this->configFactory->get('user.settings');
+      if ($user_settings->get('register') !== 'visitors') {
           // If settings don't allow to create a new account, then don't.
           drupal_set_message(
             t('You can\'t login using this account. Please use another e-mail address or ask an administrator to setup an account.'),


### PR DESCRIPTION
Currently, d8-google-login creates a new account in Drupal if the used Google account does not match any known account.

This is also the case if the site is configured to *not* accept users to self-register.

This change fixes that -- the account is only created if setting user.settings.register is set to
'visitors'.